### PR TITLE
docs: update Vite version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Features
 
-- ⚡️ React TypeScript template with [Vite 2](https://vitejs.dev/)
+- ⚡️ React TypeScript template with [Vite 5](https://vitejs.dev/)
 - 📦 [Hardhat](https://hardhat.org/) - Ethereum development environment for professionals
 - 🦾 [TypeChain Hardhat plugin](https://github.com/ethereum-ts/TypeChain/tree/master/packages/hardhat) - Automatically generate TypeScript bindings for smartcontracts while using Hardhat.
 - 🔥 [web3-react](https://github.com/NoahZinsmeister/web3-react/) - A simple, maximally extensible, dependency minimized framework for building modern Ethereum dApps


### PR DESCRIPTION
The project is now using Vite 5, here's a screenshot from running latest `main`:

<img width="222" alt="image" src="https://github.com/jellydn/nft-app/assets/16504501/598798cf-647f-42c8-b196-dff7d476c170">
